### PR TITLE
use renamed elixir_uuid and update deps and credo

### DIFF
--- a/lib/rock/struct/heap.ex
+++ b/lib/rock/struct/heap.ex
@@ -6,13 +6,14 @@ defmodule Rock.Struct.Heap do
   alias Rock.ClusterMergeCriterion
   @moduledoc false
 
-  def new(%Cluster{} = cluster,
-      other_clusters,
-      link_matrix,
-      theta) do
-
+  def new(
+        %Cluster{} = cluster,
+        other_clusters,
+        link_matrix,
+        theta
+      ) do
     if other_clusters |> Enum.member?(cluster),
-      do: raise ArgumentError, message: "cluster can not be member of heap items clusters"
+      do: raise(ArgumentError, message: "cluster can not be member of heap items clusters")
 
     items = cluster |> prepare_items(other_clusters, link_matrix, theta)
 
@@ -25,13 +26,14 @@ defmodule Rock.Struct.Heap do
     %Heap{cluster: cluster, items: new_items}
   end
 
-  def add_item(%Heap{items: items, cluster: heap_cluster},
-      %Cluster{uuid: uuid} = cluster,
-      cross_link_count,
-      theta) do
-
+  def add_item(
+        %Heap{items: items, cluster: heap_cluster},
+        %Cluster{uuid: uuid} = cluster,
+        cross_link_count,
+        theta
+      ) do
     if uuid |> exists_in_items?(items),
-      do: raise ArgumentError, message: "cluster is already member of the heap"
+      do: raise(ArgumentError, message: "cluster is already member of the heap")
 
     new_item = heap_cluster |> calculate_item(cluster, cross_link_count, theta)
     new_items = [new_item | items] |> sort
@@ -39,14 +41,17 @@ defmodule Rock.Struct.Heap do
     %Heap{cluster: heap_cluster, items: new_items}
   end
 
-  def find_item(%Heap{cluster: %Cluster{uuid: cluster_uuid}},
-                      uuid) when uuid == cluster_uuid do
+  def find_item(
+        %Heap{cluster: %Cluster{uuid: cluster_uuid}},
+        uuid
+      )
+      when uuid == cluster_uuid do
     nil
   end
 
   def find_item(%Heap{items: items}, uuid) do
     items
-    |> Enum.find(fn({_, _, cluster_uuid}) ->
+    |> Enum.find(fn {_, _, cluster_uuid} ->
       cluster_uuid == uuid
     end)
   end
@@ -59,13 +64,12 @@ defmodule Rock.Struct.Heap do
 
   defp exists_in_items?(uuid, items) do
     items
-    |> Enum.any?(fn({_, _, cluster_uuid}) ->
+    |> Enum.any?(fn {_, _, cluster_uuid} ->
       cluster_uuid == uuid
     end)
   end
 
-  defp _remove_item(items,
-    [{_, _, cluster_uuid} = item | _], uuid) when cluster_uuid == uuid do
+  defp _remove_item(items, [{_, _, cluster_uuid} = item | _], uuid) when cluster_uuid == uuid do
     items |> List.delete(item)
   end
 
@@ -89,11 +93,13 @@ defmodule Rock.Struct.Heap do
     |> Enum.map(&calculate_item(cluster, &1, link_matrix, theta))
   end
 
-  defp calculate_item(cluster,
-      other_cluster = %Cluster{uuid: uuid},
-      cross_link_count,
-      theta) when is_number(cross_link_count) do
-
+  defp calculate_item(
+         cluster,
+         %Cluster{uuid: uuid} = other_cluster,
+         cross_link_count,
+         theta
+       )
+       when is_number(cross_link_count) do
     measure =
       ClusterMergeCriterion.measure(
         cluster,
@@ -105,11 +111,12 @@ defmodule Rock.Struct.Heap do
     {measure, cross_link_count, uuid}
   end
 
-  defp calculate_item(cluster,
-      other_cluster = %Cluster{uuid: uuid},
-      link_matrix,
-      theta) do
-
+  defp calculate_item(
+         cluster,
+         %Cluster{uuid: uuid} = other_cluster,
+         link_matrix,
+         theta
+       ) do
     {measure, cross_link_count} =
       link_matrix
       |> ClusterMergeCriterion.measure(cluster, other_cluster, theta)
@@ -119,15 +126,15 @@ defmodule Rock.Struct.Heap do
 
   defp remove_empty_links(items) do
     items
-    |> Enum.filter(fn({_, cross_link_count, _}) ->
+    |> Enum.filter(fn {_, cross_link_count, _} ->
       cross_link_count != 0
     end)
   end
 
   defp sort(items) do
     items
-    |> Enum.sort_by(fn({measure, _, _}) ->
-      - measure
+    |> Enum.sort_by(fn {measure, _, _} ->
+      -measure
     end)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,20 +1,23 @@
 defmodule Rock.Mixfile do
+  @moduledoc false
+
   use Mix.Project
 
   def project do
-    [app: :rock,
-     version: "0.1.0",
-     elixir: "~> 1.4",
-     description: "ROCK: A Robust Clustering Algorithm for Categorical Attributes",
-     package: [
-       maintainers: ["Ayrat Badykov"],
-       licenses: ["MIT"],
-       links: %{"GitHub" => "https://github.com/ayrat555/rock"}
-     ],
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps(),
-     elixirc_paths: elixirc_paths(Mix.env)
+    [
+      app: :rock,
+      version: "0.1.1",
+      elixir: "~> 1.4",
+      description: "ROCK: A Robust Clustering Algorithm for Categorical Attributes",
+      package: [
+        maintainers: ["Ayrat Badykov"],
+        licenses: ["MIT"],
+        links: %{"GitHub" => "https://github.com/ayrat555/rock"}
+      ],
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      elixirc_paths: elixirc_paths(Mix.env())
     ]
   end
 
@@ -24,14 +27,13 @@ defmodule Rock.Mixfile do
 
   defp deps do
     [
-      {:credo, "~> 0.7", only: [:dev, :test]},
-      {:uuid, "~> 1.1"},
-      {:apex, "~> 1.0.0", only: [:dev, :test]},
-      {:ex_doc, "~> 0.14", only: :dev, runtime: false}
+      {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
+      {:elixir_uuid, "~> 1.2"},
+      {:apex, "~> 1.2", only: [:dev, :test]},
+      {:ex_doc, "~> 0.22", only: :dev, runtime: false}
     ]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 end
-

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,14 @@
-%{"apex": {:hex, :apex, "1.0.0", "abf230314d35ca4c48a902f693247f190ad42fc14862b9c4f7dbb7077b21c20a", [:mix], [], "hexpm"},
-  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
-  "credo": {:hex, :credo, "0.7.3", "9827ab04002186af1aec014a811839a06f72aaae6cd5eed3919b248c8767dbf3", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "uuid": {:hex, :uuid, "1.1.7", "007afd58273bc0bc7f849c3bdc763e2f8124e83b957e515368c498b641f7ab69", [:mix], [], "hexpm"}}
+%{
+  "apex": {:hex, :apex, "1.2.1", "297f5dac23fa2a32648b890a0838fce2772114010e0b9ec975cae6021cc5a092", [:mix], [], "hexpm", "379e2515fa5da7a5ac91ecceba782169d1a734e7e09e5f473e4e85576728b65f"},
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
+  "credo": {:hex, :credo, "1.4.0", "92339d4cbadd1e88b5ee43d427b639b68a11071b6f73854e33638e30a0ea11f5", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "1fd3b70dce216574ce3c18bdf510b57e7c4c85c2ec9cad4bff854abaf7e58658"},
+  "earmark": {:hex, :earmark, "1.4.9", "837e4c1c5302b3135e9955f2bbf52c6c52e950c383983942b68b03909356c0d9", [:mix], [{:earmark_parser, ">= 1.4.9", [hex: :earmark_parser, repo: "hexpm", optional: false]}], "hexpm", "0d72df7d13a3dc8422882bed5263fdec5a773f56f7baeb02379361cb9e5b0d8e"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.9", "819bda2049e6ee1365424e4ced1ba65806eacf0d2867415f19f3f80047f8037b", [:mix], [], "hexpm", "8bf54fddabf2d7e137a0c22660e71b49d5a0a82d1fb05b5af62f2761cd6485c4"},
+  "elixir_uuid": {:hex, :elixir_uuid, "1.2.1", "dce506597acb7e6b0daeaff52ff6a9043f5919a4c3315abb4143f0b00378c097", [:mix], [], "hexpm", "f7eba2ea6c3555cea09706492716b0d87397b88946e6380898c2889d68585752"},
+  "ex_doc": {:hex, :ex_doc, "0.22.1", "9bb6d51508778193a4ea90fa16eac47f8b67934f33f8271d5e1edec2dc0eee4c", [:mix], [{:earmark, "~> 1.4.0", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "d957de1b75cb9f78d3ee17820733dc4460114d8b1e11f7ee4fd6546e69b1db60"},
+  "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b659b8571deedf60f79c5a608e15414085fa141344e2716fbd6988a084b5f993"},
+  "makeup": {:hex, :makeup, "1.0.3", "e339e2f766d12e7260e6672dd4047405963c5ec99661abdc432e6ec67d29ef95", [:mix], [{:nimble_parsec, "~> 0.5", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "2e9b4996d11832947731f7608fed7ad2f9443011b3b479ae288011265cdd3dad"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.1", "4f0e96847c63c17841d42c08107405a005a2680eb9c7ccadfd757bd31dabccfb", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "f2438b1a80eaec9ede832b5c41cd4f373b38fd7aa33e3b22d9db79e640cbde11"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.6.0", "32111b3bf39137144abd7ba1cce0914533b2d16ef35e8abc5ec8be6122944263", [:mix], [], "hexpm", "27eac315a94909d4dc68bc07a4a83e06c8379237c5ea528a9acff4ca1c873c52"},
+  "uuid": {:hex, :uuid, "1.1.7", "007afd58273bc0bc7f849c3bdc763e2f8124e83b957e515368c498b641f7ab69", [:mix], [], "hexpm"},
+}

--- a/test/support/test_factory.ex
+++ b/test/support/test_factory.ex
@@ -1,4 +1,6 @@
 defmodule Rock.Test.TestFactory do
+  @moduledoc false
+
   alias Rock.Struct.Point
   alias Rock.Struct.Cluster
   alias Rock.Struct.Heap


### PR DESCRIPTION
`uuid` was renamed to `elixir_uuid` so I changed this dep name and fix two credo errors -- one for the ordering of assignment destructuring and one for moduledoc's missing.  All tests pass